### PR TITLE
Move calc var inside money object. Expose Amount.

### DIFF
--- a/calculator.go
+++ b/calculator.go
@@ -48,7 +48,7 @@ func (c *calculator) round(a *Amount) *Amount {
 		return &Amount{0}
 	}
 
-	absam := calc.absolute(a)
+	absam := c.absolute(a)
 	m := absam.val % 100
 
 	if m > 50 {

--- a/money.go
+++ b/money.go
@@ -14,7 +14,6 @@ type Amount struct {
 type Money struct {
 	amount   *Amount
 	currency *Currency
-	calc     *calculator
 }
 
 // New creates and returns new instance of Money
@@ -22,7 +21,6 @@ func New(amount int64, code string) *Money {
 	return &Money{
 		amount:   &Amount{val: amount},
 		currency: newCurrency(code),
-		calc:     &calculator{},
 	}
 }
 
@@ -117,12 +115,12 @@ func (m *Money) IsNegative() bool {
 
 // Absolute returns new Money struct from given Money using absolute monetary value
 func (m *Money) Absolute() *Money {
-	return &Money{amount: m.calc.absolute(m.amount), currency: m.currency, calc: &calculator{}}
+	return &Money{amount: mutate.calc.absolute(m.amount), currency: m.currency}
 }
 
 // Negative returns new Money struct from given Money using negative monetary value
 func (m *Money) Negative() *Money {
-	return &Money{amount: m.calc.negative(m.amount), currency: m.currency, calc: &calculator{}}
+	return &Money{amount: mutate.calc.negative(m.amount), currency: m.currency}
 }
 
 // Add returns new Money struct with value representing sum of Self and Other Money
@@ -131,7 +129,7 @@ func (m *Money) Add(om *Money) (*Money, error) {
 		return nil, err
 	}
 
-	return &Money{amount: m.calc.add(m.amount, om.amount), currency: m.currency, calc: &calculator{}}, nil
+	return &Money{amount: mutate.calc.add(m.amount, om.amount), currency: m.currency}, nil
 }
 
 // Subtract returns new Money struct with value representing difference of Self and Other Money
@@ -140,22 +138,22 @@ func (m *Money) Subtract(om *Money) (*Money, error) {
 		return nil, err
 	}
 
-	return &Money{amount: m.calc.subtract(m.amount, om.amount), currency: m.currency, calc: &calculator{}}, nil
+	return &Money{amount: mutate.calc.subtract(m.amount, om.amount), currency: m.currency}, nil
 }
 
 // Multiply returns new Money struct with value representing Self multiplied value by multiplier
 func (m *Money) Multiply(mul int64) *Money {
-	return &Money{amount: m.calc.multiply(m.amount, mul), currency: m.currency, calc: &calculator{}}
+	return &Money{amount: mutate.calc.multiply(m.amount, mul), currency: m.currency}
 }
 
 // Divide returns new Money struct with value representing Self division value by given divider
 func (m *Money) Divide(div int64) *Money {
-	return &Money{amount: m.calc.divide(m.amount, div), currency: m.currency, calc: &calculator{}}
+	return &Money{amount: mutate.calc.divide(m.amount, div), currency: m.currency}
 }
 
 // Round returns new Money struct with value rounded to nearest zero
 func (m *Money) Round() *Money {
-	return &Money{amount: m.calc.round(m.amount), currency: m.currency, calc: &calculator{}}
+	return &Money{amount: mutate.calc.round(m.amount), currency: m.currency}
 }
 
 // Split returns slice of Money structs with split Self value in given number.
@@ -166,18 +164,18 @@ func (m *Money) Split(n int) ([]*Money, error) {
 		return nil, errors.New("Split must be higher than zero")
 	}
 
-	a := m.calc.divide(m.amount, int64(n))
+	a := mutate.calc.divide(m.amount, int64(n))
 	ms := make([]*Money, n)
 
 	for i := 0; i < n; i++ {
-		ms[i] = &Money{amount: a, currency: m.currency, calc: &calculator{}}
+		ms[i] = &Money{amount: a, currency: m.currency}
 	}
 
-	l := m.calc.modulus(m.amount, int64(n)).val
+	l := mutate.calc.modulus(m.amount, int64(n)).val
 
 	// Add leftovers to the first parties
 	for p := 0; l != 0; p++ {
-		ms[p].amount = m.calc.add(ms[p].amount, &Amount{1})
+		ms[p].amount = mutate.calc.add(ms[p].amount, &Amount{1})
 		l--
 	}
 
@@ -202,9 +200,8 @@ func (m *Money) Allocate(rs []int) ([]*Money, error) {
 	var ms []*Money
 	for _, r := range rs {
 		party := &Money{
-			amount:   m.calc.allocate(m.amount, r, sum),
+			amount:   mutate.calc.allocate(m.amount, r, sum),
 			currency: m.currency,
-			calc:     &calculator{},
 		}
 
 		ms = append(ms, party)
@@ -219,7 +216,7 @@ func (m *Money) Allocate(rs []int) ([]*Money, error) {
 	}
 
 	for p := 0; lo != 0; p++ {
-		ms[p].amount = m.calc.add(ms[p].amount, &Amount{sub})
+		ms[p].amount = mutate.calc.add(ms[p].amount, &Amount{sub})
 		lo -= sub
 	}
 

--- a/money.go
+++ b/money.go
@@ -26,6 +26,11 @@ func New(amount int64, code string) *Money {
 	}
 }
 
+// Amount returns a copy of the internal monetary value as an int64
+func (m *Money) Amount() int64 {
+	return m.amount.val
+}
+
 // SameCurrency check if given Money is equals by currency
 func (m *Money) SameCurrency(om *Money) bool {
 	return m.currency.equals(om.currency)

--- a/money.go
+++ b/money.go
@@ -14,17 +14,15 @@ type Amount struct {
 type Money struct {
 	amount   *Amount
 	currency *Currency
+	calc     *calculator
 }
-
-var calc *calculator
 
 // New creates and returns new instance of Money
 func New(amount int64, code string) *Money {
-	calc = new(calculator)
-
 	return &Money{
 		amount:   &Amount{val: amount},
 		currency: newCurrency(code),
+		calc:     &calculator{},
 	}
 }
 
@@ -114,12 +112,12 @@ func (m *Money) IsNegative() bool {
 
 // Absolute returns new Money struct from given Money using absolute monetary value
 func (m *Money) Absolute() *Money {
-	return &Money{calc.absolute(m.amount), m.currency}
+	return &Money{amount: m.calc.absolute(m.amount), currency: m.currency, calc: &calculator{}}
 }
 
 // Negative returns new Money struct from given Money using negative monetary value
 func (m *Money) Negative() *Money {
-	return &Money{calc.negative(m.amount), m.currency}
+	return &Money{amount: m.calc.negative(m.amount), currency: m.currency, calc: &calculator{}}
 }
 
 // Add returns new Money struct with value representing sum of Self and Other Money
@@ -128,7 +126,7 @@ func (m *Money) Add(om *Money) (*Money, error) {
 		return nil, err
 	}
 
-	return &Money{calc.add(m.amount, om.amount), m.currency}, nil
+	return &Money{amount: m.calc.add(m.amount, om.amount), currency: m.currency, calc: &calculator{}}, nil
 }
 
 // Subtract returns new Money struct with value representing difference of Self and Other Money
@@ -137,22 +135,22 @@ func (m *Money) Subtract(om *Money) (*Money, error) {
 		return nil, err
 	}
 
-	return &Money{calc.subtract(m.amount, om.amount), m.currency}, nil
+	return &Money{amount: m.calc.subtract(m.amount, om.amount), currency: m.currency, calc: &calculator{}}, nil
 }
 
 // Multiply returns new Money struct with value representing Self multiplied value by multiplier
 func (m *Money) Multiply(mul int64) *Money {
-	return &Money{calc.multiply(m.amount, mul), m.currency}
+	return &Money{amount: m.calc.multiply(m.amount, mul), currency: m.currency, calc: &calculator{}}
 }
 
 // Divide returns new Money struct with value representing Self division value by given divider
 func (m *Money) Divide(div int64) *Money {
-	return &Money{calc.divide(m.amount, div), m.currency}
+	return &Money{amount: m.calc.divide(m.amount, div), currency: m.currency, calc: &calculator{}}
 }
 
 // Round returns new Money struct with value rounded to nearest zero
 func (m *Money) Round() *Money {
-	return &Money{calc.round(m.amount), m.currency}
+	return &Money{amount: m.calc.round(m.amount), currency: m.currency, calc: &calculator{}}
 }
 
 // Split returns slice of Money structs with split Self value in given number.
@@ -163,18 +161,18 @@ func (m *Money) Split(n int) ([]*Money, error) {
 		return nil, errors.New("Split must be higher than zero")
 	}
 
-	a := calc.divide(m.amount, int64(n))
+	a := m.calc.divide(m.amount, int64(n))
 	ms := make([]*Money, n)
 
 	for i := 0; i < n; i++ {
-		ms[i] = &Money{a, m.currency}
+		ms[i] = &Money{amount: a, currency: m.currency, calc: &calculator{}}
 	}
 
-	l := calc.modulus(m.amount, int64(n)).val
+	l := m.calc.modulus(m.amount, int64(n)).val
 
 	// Add leftovers to the first parties
 	for p := 0; l != 0; p++ {
-		ms[p].amount = calc.add(ms[p].amount, &Amount{1})
+		ms[p].amount = m.calc.add(ms[p].amount, &Amount{1})
 		l--
 	}
 
@@ -199,8 +197,9 @@ func (m *Money) Allocate(rs []int) ([]*Money, error) {
 	var ms []*Money
 	for _, r := range rs {
 		party := &Money{
-			calc.allocate(m.amount, r, sum),
-			m.currency,
+			amount:   m.calc.allocate(m.amount, r, sum),
+			currency: m.currency,
+			calc:     &calculator{},
 		}
 
 		ms = append(ms, party)
@@ -215,7 +214,7 @@ func (m *Money) Allocate(rs []int) ([]*Money, error) {
 	}
 
 	for p := 0; lo != 0; p++ {
-		ms[p].amount = calc.add(ms[p].amount, &Amount{sub})
+		ms[p].amount = m.calc.add(ms[p].amount, &Amount{sub})
 		lo -= sub
 	}
 

--- a/money_test.go
+++ b/money_test.go
@@ -518,17 +518,17 @@ func TestMoney_Comparison(t *testing.T) {
 	twoPounds := New(200, "GBP")
 	twoEuros := New(200, "EUR")
 
-	if r, err := pound.GreaterThan(twoPounds); err != nil || r != false {
+	if r, err := pound.GreaterThan(twoPounds); err != nil || !r {
 		t.Errorf("Expected %d Greater Than %d == %t got %t", pound.amount.val,
 			twoPounds.amount.val, false, r)
 	}
 
-	if r, err := pound.LessThan(twoPounds); err != nil || r != true {
+	if r, err := pound.LessThan(twoPounds); err != nil || r {
 		t.Errorf("Expected %d Less Than %d == %t got %t", pound.amount.val,
 			twoPounds.amount.val, true, r)
 	}
 
-	if r, err := pound.LessThan(twoEuros); err == nil || r != false {
+	if r, err := pound.LessThan(twoEuros); err == nil || !r {
 		t.Error("Expected err")
 	}
 }

--- a/money_test.go
+++ b/money_test.go
@@ -518,17 +518,17 @@ func TestMoney_Comparison(t *testing.T) {
 	twoPounds := New(200, "GBP")
 	twoEuros := New(200, "EUR")
 
-	if r, err := pound.GreaterThan(twoPounds); err != nil || !r {
+	if r, err := pound.GreaterThan(twoPounds); err != nil || r {
 		t.Errorf("Expected %d Greater Than %d == %t got %t", pound.amount.val,
 			twoPounds.amount.val, false, r)
 	}
 
-	if r, err := pound.LessThan(twoPounds); err != nil || r {
+	if r, err := pound.LessThan(twoPounds); err != nil || !r {
 		t.Errorf("Expected %d Less Than %d == %t got %t", pound.amount.val,
 			twoPounds.amount.val, true, r)
 	}
 
-	if r, err := pound.LessThan(twoEuros); err == nil || !r {
+	if r, err := pound.LessThan(twoEuros); err == nil || r {
 		t.Error("Expected err")
 	}
 }

--- a/mutator.go
+++ b/mutator.go
@@ -1,0 +1,8 @@
+package money
+
+type mutator struct {
+	calc *calculator
+}
+
+// initialize our default mutator here
+var mutate = mutator{calc: &calculator{}}


### PR DESCRIPTION
The calc var was global and recreated with each new money object which will cause races.

This PR fixes that issue.

Fix #16