### PR TITLE
Remove divide from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ Operations
 -
 * Add
 * Subtract
-* Divide
 * Multiply
 * Absolute
 * Negative
@@ -153,23 +152,6 @@ pound := money.New(100, "GBP")
 
 result := pound.Multiply(2) // £2.00
 ```
-
-#### Division
-
-Division can be performed using `Divide()`.
-
-```go
-pound := money.New(100, "GBP")
-
-result := pound.Divide(2) // £0.50
-```
-
-There is possibilities to lose pennies by using division operation e.g:
-```go
-money.New(100, "GBP").Divide(3) // £0.33
-```
-In order to split amount without losing use `Split()` operation.
-
 
 #### Absolute
 


### PR DESCRIPTION
When trying out this package I got confused when I could not find the divide operation as stated in the docs, then I noticed it was removed in https://github.com/Rhymond/go-money/commit/0a64d6a926bb6aade662a29f6cfcc49d06ea7b56