### PR TITLE
Export an error for currency mismatches

### DIFF
--- a/money.go
+++ b/money.go
@@ -16,6 +16,9 @@ var (
 	UnmarshalJSON = defaultUnmarshalJSON
 	// MarshalJSONFunc is injection point of json.Marshaller for money.Money
 	MarshalJSON = defaultMarshalJSON
+
+	// ErrCurrencyMismatch happens when two compared Money don't have the same currency.
+	ErrCurrencyMismatch = errors.New("currencies don't match")
 )
 
 func defaultUnmarshalJSON(m *Money, b []byte) error {
@@ -71,7 +74,7 @@ func (m *Money) SameCurrency(om *Money) bool {
 
 func (m *Money) assertSameCurrency(om *Money) error {
 	if !m.SameCurrency(om) {
-		return errors.New("currencies don't match")
+		return ErrCurrencyMismatch
 	}
 
 	return nil

--- a/money_test.go
+++ b/money_test.go
@@ -3,6 +3,7 @@ package money
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -75,6 +76,18 @@ func TestMoney_Equals(t *testing.T) {
 			t.Errorf("Expected %d Equals %d == %t got %t", m.amount.val,
 				om.amount.val, tc.expected, r)
 		}
+	}
+}
+
+func TestMoney_Equals_DifferentCurrencies(t *testing.T) {
+	t.Parallel()
+
+	eur := New(0, EUR)
+	usd := New(0, USD)
+
+	_, err := eur.Equals(usd)
+	if err == nil || !errors.Is(ErrCurrencyMismatch, err) {
+		t.Errorf("Expected Equals to return %q, got %v", ErrCurrencyMismatch.Error(), err)
 	}
 }
 


### PR DESCRIPTION
Hi!

I started using your library, and would loved to be able to filter `Add` errors on `ErrCurrencyMismatch`.
In this PR, I export this error so it is usable when using the library.

I also tried to follow the standards in this repository when writing a non-regression test.