### PR TITLE
Fix marshalling the zero value of Money to JSON

### DIFF
--- a/money.go
+++ b/money.go
@@ -19,6 +19,9 @@ var (
 
 	// ErrCurrencyMismatch happens when two compared Money don't have the same currency.
 	ErrCurrencyMismatch = errors.New("currencies don't match")
+
+	// ErrInvalidJSONUnmarshal happens when the default money.UnmarshalJSON fails to unmarshal Money because of invalid data.
+	ErrInvalidJSONUnmarshal = errors.New("invalid json unmarshal")
 )
 
 func defaultUnmarshalJSON(m *Money, b []byte) error {
@@ -30,12 +33,18 @@ func defaultUnmarshalJSON(m *Money, b []byte) error {
 
 	var amount float64
 	if amountRaw, ok := data["amount"]; ok {
-		amount = amountRaw.(float64)
+		amount, ok = amountRaw.(float64)
+		if !ok {
+			return ErrInvalidJSONUnmarshal
+		}
 	}
 
 	var currency string
 	if currencyRaw, ok := data["currency"]; ok {
-		currency = currencyRaw.(string)
+		currency, ok = currencyRaw.(string)
+		if !ok {
+			return ErrInvalidJSONUnmarshal
+		}
 	}
 
 	var ref *Money

--- a/money.go
+++ b/money.go
@@ -28,14 +28,22 @@ func defaultUnmarshalJSON(m *Money, b []byte) error {
 		return err
 	}
 
-	amount := int64(data["amount"].(float64))
-	currency := data["currency"].(string)
+	amountRaw := data["amount"]
+	var amount float64
+	if amountRaw != nil {
+		amount = amountRaw.(float64)
+	}
+	currencyRaw := data["currency"]
+	var currency string
+	if currencyRaw != nil {
+		currency = data["currency"].(string)
+	}
 
 	var ref *Money
 	if amount == 0 && currency == "" {
 		ref = &Money{}
 	} else {
-		ref = New(amount, currency)
+		ref = New(int64(amount), currency)
 	}
 
 	*m = *ref

--- a/money.go
+++ b/money.go
@@ -35,7 +35,7 @@ func defaultUnmarshalJSON(m *Money, b []byte) error {
 	if amount == 0 && currency == "" {
 		ref = &Money{}
 	} else {
-		ref = New(int64(data["amount"].(float64)), data["currency"].(string))
+		ref = New(amount, currency)
 	}
 
 	*m = *ref

--- a/money.go
+++ b/money.go
@@ -33,6 +33,10 @@ func defaultUnmarshalJSON(m *Money, b []byte) error {
 }
 
 func defaultMarshalJSON(m Money) ([]byte, error) {
+	if m == (Money{}) {
+		m = *New(0, "")
+	}
+
 	buff := bytes.NewBufferString(fmt.Sprintf(`{"amount": %d, "currency": "%s"}`, m.Amount(), m.Currency().Code))
 	return buff.Bytes(), nil
 }

--- a/money.go
+++ b/money.go
@@ -27,7 +27,17 @@ func defaultUnmarshalJSON(m *Money, b []byte) error {
 	if err != nil {
 		return err
 	}
-	ref := New(int64(data["amount"].(float64)), data["currency"].(string))
+
+	amount := int64(data["amount"].(float64))
+	currency := data["currency"].(string)
+
+	var ref *Money
+	if amount == 0 && currency == "" {
+		ref = &Money{}
+	} else {
+		ref = New(int64(data["amount"].(float64)), data["currency"].(string))
+	}
+
 	*m = *ref
 	return nil
 }

--- a/money.go
+++ b/money.go
@@ -28,15 +28,14 @@ func defaultUnmarshalJSON(m *Money, b []byte) error {
 		return err
 	}
 
-	amountRaw := data["amount"]
 	var amount float64
-	if amountRaw != nil {
+	if amountRaw, ok := data["amount"]; ok {
 		amount = amountRaw.(float64)
 	}
-	currencyRaw := data["currency"]
+
 	var currency string
-	if currencyRaw != nil {
-		currency = data["currency"].(string)
+	if currencyRaw, ok := data["currency"]; ok {
+		currency = currencyRaw.(string)
 	}
 
 	var ref *Money

--- a/money_test.go
+++ b/money_test.go
@@ -695,6 +695,16 @@ func TestDefaultUnmarshal(t *testing.T) {
 	if m != (Money{}) {
 		t.Errorf("Expected zero value, got %+v", m)
 	}
+
+	given = `{}`
+	err = json.Unmarshal([]byte(given), &m)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if m != (Money{}) {
+		t.Errorf("Expected zero value, got %+v", m)
+	}
 }
 
 func TestCustomUnmarshal(t *testing.T) {

--- a/money_test.go
+++ b/money_test.go
@@ -685,6 +685,16 @@ func TestDefaultUnmarshal(t *testing.T) {
 	if m.Display() != expected {
 		t.Errorf("Expected %s got %s", expected, m.Display())
 	}
+
+	given = `{"amount": 0, "currency":""}`
+	err = json.Unmarshal([]byte(given), &m)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if m != (Money{}) {
+		t.Errorf("Expected zero value, got %+v", m)
+	}
 }
 
 func TestCustomUnmarshal(t *testing.T) {

--- a/money_test.go
+++ b/money_test.go
@@ -705,6 +705,18 @@ func TestDefaultUnmarshal(t *testing.T) {
 	if m != (Money{}) {
 		t.Errorf("Expected zero value, got %+v", m)
 	}
+
+	given = `{"amount": "foo", "currency": "USD"}`
+	err = json.Unmarshal([]byte(given), &m)
+	if !errors.Is(err, ErrInvalidJSONUnmarshal) {
+		t.Errorf("Expected ErrInvalidJSONUnmarshal, got %+v", err)
+	}
+
+	given = `{"amount": 1234, "currency": 1234}`
+	err = json.Unmarshal([]byte(given), &m)
+	if !errors.Is(err, ErrInvalidJSONUnmarshal) {
+		t.Errorf("Expected ErrInvalidJSONUnmarshal, got %+v", err)
+	}
 }
 
 func TestCustomUnmarshal(t *testing.T) {

--- a/money_test.go
+++ b/money_test.go
@@ -639,6 +639,19 @@ func TestDefaultMarshal(t *testing.T) {
 	if string(b) != expected {
 		t.Errorf("Expected %s got %s", expected, string(b))
 	}
+
+	given = &Money{}
+	expected = `{"amount":0,"currency":""}`
+
+	b, err = json.Marshal(given)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if string(b) != expected {
+		t.Errorf("Expected %s got %s", expected, string(b))
+	}
 }
 
 func TestCustomMarshal(t *testing.T) {


### PR DESCRIPTION
Thanks for the great library!

I hit a nil pointer dereference when I was marshalling a struct with a `Money` field to JSON. For example:
```go
type Product struct {
  Price money.Money
}

json.Marshal(Product{}) // uh oh! nil pointer deference
```

Pretty quick fix by checking for the zero value and using the constructor in that case. Figured I'd put up a PR since it was so simple. I can work around by swapping out the default marshaling function, but this seems like a better fix for a problem others might hit!