### PR TITLE
Appropriate code for ZWL. ZWD must have unique numeric code

### DIFF
--- a/currency.go
+++ b/currency.go
@@ -216,8 +216,8 @@ var currencies = Currencies{
 	YER: {Decimal: ".", Thousand: ",", Code: YER, Fraction: 2, NumericCode: "886", Grapheme: "\ufdfc", Template: "1 $"},
 	ZAR: {Decimal: ".", Thousand: ",", Code: ZAR, Fraction: 2, NumericCode: "710", Grapheme: "R", Template: "$1"},
 	ZMW: {Decimal: ".", Thousand: ",", Code: ZMW, Fraction: 2, NumericCode: "967", Grapheme: "ZK", Template: "$1"},
-	ZWD: {Decimal: ".", Thousand: ",", Code: ZWD, Fraction: 2, NumericCode: "932", Grapheme: "Z$", Template: "$1"},
-	ZWL: {Decimal: ".", Thousand: ",", Code: ZWD, Fraction: 2, NumericCode: "932", Grapheme: "Z$", Template: "$1"},
+	ZWD: {Decimal: ".", Thousand: ",", Code: ZWD, Fraction: 2, NumericCode: "716", Grapheme: "Z$", Template: "$1"},
+	ZWL: {Decimal: ".", Thousand: ",", Code: ZWL, Fraction: 2, NumericCode: "932", Grapheme: "Z$", Template: "$1"},
 }
 
 // AddCurrency lets you insert or update currency in currencies list.


### PR DESCRIPTION
ZWD code [must be 716](https://en.wikipedia.org/wiki/ISO_4217#Historical_codes) instead of 932
932 is for ZWL
![image](https://github.com/Rhymond/go-money/assets/99190728/0082571c-fabb-4347-bcd4-4d34300b208d)

Related to this issue: https://github.com/Rhymond/go-money/issues/131
