### PR TITLE
Add shopspring/decimal support to avoid float precisions

### DIFF
--- a/calculator.go
+++ b/calculator.go
@@ -1,73 +1,52 @@
 package money
 
-import "math"
+import (
+	"github.com/shopspring/decimal"
+)
 
 type calculator struct{}
 
 func (c *calculator) add(a, b Amount) Amount {
-	return a + b
+	return a.Add(b)
 }
 
 func (c *calculator) subtract(a, b Amount) Amount {
-	return a - b
+	return a.Sub(b)
 }
 
 func (c *calculator) multiply(a Amount, m int64) Amount {
-	return a * m
+	return a.Mul(decimal.NewFromInt(m))
 }
 
 func (c *calculator) divide(a Amount, d int64) Amount {
-	return a / d
+	return a.Div(decimal.NewFromInt(d))
 }
 
 func (c *calculator) modulus(a Amount, d int64) Amount {
-	return a % d
+	return a.Mod(decimal.NewFromInt(d))
 }
 
 func (c *calculator) allocate(a Amount, r, s uint) Amount {
-	if a == 0 || s == 0 {
-		return 0
+	if a.IsZero() || s == 0 {
+		return decimal.Zero
 	}
 
-	return a * int64(r) / int64(s)
+	res := a.Mul(decimal.NewFromInt(int64(r))).Div(decimal.NewFromInt(int64(s))).IntPart()
+	return decimal.NewFromInt(res)
 }
 
 func (c *calculator) absolute(a Amount) Amount {
-	if a < 0 {
-		return -a
-	}
-
-	return a
+	return a.Abs()
 }
 
 func (c *calculator) negative(a Amount) Amount {
-	if a > 0 {
-		return -a
+	if a.IsPositive() {
+		return a.Mul(decimal.NewFromInt(-1))
 	}
 
 	return a
 }
 
 func (c *calculator) round(a Amount, e int) Amount {
-	if a == 0 {
-		return 0
-	}
-
-	absam := c.absolute(a)
-	exp := int64(math.Pow(10, float64(e)))
-	m := absam % exp
-
-	if m > (exp / 2) {
-		absam += exp
-	}
-
-	absam = (absam / exp) * exp
-
-	if a < 0 {
-		a = -absam
-	} else {
-		a = absam
-	}
-
-	return a
+	return a.Round(int32(e * -1))
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/Rhymond/go-money
 
 go 1.13
+
+require github.com/shopspring/decimal v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
+github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/money.go
+++ b/money.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 
 	"github.com/shopspring/decimal"
 )
@@ -92,8 +91,9 @@ func New(amount int64, code string) *Money {
 // NewFromFloat creates and returns new instance of Money from a float64.
 // Always rounding trailing decimals down.
 func NewFromFloat(amount float64, currency string) *Money {
-	currencyDecimals := math.Pow10(GetCurrency(currency).Fraction)
-	return New(int64(amount*currencyDecimals), currency)
+	c := GetCurrency(currency)
+	amt := decimal.NewFromFloat(amount).Mul(decimal.New(1, int32(c.Fraction)))
+	return New(amt.IntPart(), currency)
 }
 
 // Currency returns the currency used by Money.

--- a/money_example_test.go
+++ b/money_example_test.go
@@ -40,6 +40,14 @@ func ExampleNew() {
 	// £1.00
 }
 
+func ExampleNewFromFloat() {
+	amount := 136.98
+	fmt.Println(money.NewFromFloat(amount, "SGD").Display())
+
+	// Output:
+	// $136.98
+}
+
 func ExampleMoney_comparisons() {
 	pound := money.New(100, "GBP")
 	twoPounds := money.New(200, "GBP")

--- a/money_test.go
+++ b/money_test.go
@@ -7,12 +7,14 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/shopspring/decimal"
 )
 
 func TestNew(t *testing.T) {
 	m := New(1, EUR)
 
-	if m.amount != 1 {
+	if !m.amount.Equal(decimal.NewFromInt(1)) {
 		t.Errorf("Expected %d got %d", 1, m.amount)
 	}
 
@@ -22,7 +24,7 @@ func TestNew(t *testing.T) {
 
 	m = New(-100, EUR)
 
-	if m.amount != -100 {
+	if !m.amount.Equal(decimal.NewFromInt(-100)) {
 		t.Errorf("Expected %d got %d", -100, m.amount)
 	}
 }
@@ -255,7 +257,7 @@ func TestMoney_Absolute(t *testing.T) {
 		m := New(tc.amount, EUR)
 		r := m.Absolute().amount
 
-		if r != tc.expected {
+		if !r.Equal(decimal.NewFromInt(tc.expected)) {
 			t.Errorf("Expected absolute %d to be %d got %d", m.amount,
 				tc.expected, r)
 		}
@@ -276,7 +278,7 @@ func TestMoney_Negative(t *testing.T) {
 		m := New(tc.amount, EUR)
 		r := m.Negative().amount
 
-		if r != tc.expected {
+		if !r.Equal(decimal.NewFromInt(tc.expected)) {
 			t.Errorf("Expected absolute %d to be %d got %d", m.amount,
 				tc.expected, r)
 		}
@@ -340,7 +342,7 @@ func TestMoney_Subtract(t *testing.T) {
 			t.Error(err)
 		}
 
-		if r.amount != tc.expected {
+		if !r.amount.Equal(decimal.NewFromInt(tc.expected)) {
 			t.Errorf("Expected %d - %d = %d got %d", tc.amount1, tc.amount2,
 				tc.expected, r.amount)
 		}
@@ -373,7 +375,7 @@ func TestMoney_Multiply(t *testing.T) {
 		m := New(tc.amount, EUR)
 		r := m.Multiply(tc.multiplier).amount
 
-		if r != tc.expected {
+		if !r.Equal(decimal.NewFromInt(tc.expected)) {
 			t.Errorf("Expected %d * %d = %d got %d", tc.amount, tc.multiplier, tc.expected, r)
 		}
 	}
@@ -397,7 +399,7 @@ func TestMoney_Round(t *testing.T) {
 		m := New(tc.amount, EUR)
 		r := m.Round().amount
 
-		if r != tc.expected {
+		if !r.Equal(decimal.NewFromInt(tc.expected)) {
 			t.Errorf("Expected rounded %d to be %d got %d", tc.amount, tc.expected, r)
 		}
 	}
@@ -416,7 +418,7 @@ func TestMoney_RoundWithExponential(t *testing.T) {
 		m := New(tc.amount, "CUR")
 		r := m.Round().amount
 
-		if r != tc.expected {
+		if !r.Equal(decimal.NewFromInt(tc.expected)) {
 			t.Errorf("Expected rounded %d to be %d got %d", tc.amount, tc.expected, r)
 		}
 	}
@@ -442,7 +444,7 @@ func TestMoney_Split(t *testing.T) {
 		split, _ := m.Split(tc.split)
 
 		for _, party := range split {
-			rs = append(rs, party.amount)
+			rs = append(rs, party.amount.IntPart())
 		}
 
 		if !reflect.DeepEqual(tc.expected, rs) {
@@ -482,7 +484,7 @@ func TestMoney_Allocate(t *testing.T) {
 		split, _ := m.Allocate(tc.ratios...)
 
 		for _, party := range split {
-			rs = append(rs, party.amount)
+			rs = append(rs, party.amount.IntPart())
 		}
 
 		if !reflect.DeepEqual(tc.expected, rs) {
@@ -657,7 +659,7 @@ func TestMoney_Amount(t *testing.T) {
 func TestNewFromFloat(t *testing.T) {
 	m := NewFromFloat(12.34, EUR)
 
-	if m.amount != 1234 {
+	if !m.amount.Equal(decimal.NewFromInt(1234)) {
 		t.Errorf("Expected %d got %d", 1234, m.amount)
 	}
 
@@ -667,7 +669,7 @@ func TestNewFromFloat(t *testing.T) {
 
 	m = NewFromFloat(-0.125, EUR)
 
-	if m.amount != -12 {
+	if !m.amount.Equal(decimal.NewFromInt(-12)) {
 		t.Errorf("Expected %d got %d", -12, m.amount)
 	}
 }


### PR DESCRIPTION
Hello, 

First of all thanks for creating such a package, it can be really handy for some cases. I saw that for some of the issues below

https://github.com/Rhymond/go-money/issues/124

https://github.com/Rhymond/go-money/issues/121

The output is wrong which may cause huge problems since this package is used for money operations. I wanted to add https://github.com/shopspring/decimal support to avoid float precisions.

