### PR TITLE
Fix Integer Overflow in Allocate Function

### DIFF
--- a/calculator.go
+++ b/calculator.go
@@ -24,12 +24,12 @@ func (c *calculator) modulus(a Amount, d int64) Amount {
 	return a % d
 }
 
-func (c *calculator) allocate(a Amount, r, s uint) Amount {
+func (c *calculator) allocate(a Amount, r, s int64) Amount {
 	if a == 0 || s == 0 {
 		return 0
 	}
 
-	return a * int64(r) / int64(s)
+	return a * r / s
 }
 
 func (c *calculator) absolute(a Amount) Amount {

--- a/money_test.go
+++ b/money_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
 	"testing"
 )
@@ -318,7 +319,6 @@ func TestMoney_Add(t *testing.T) {
 		m := New(tc.amount1, EUR)
 		om := New(tc.amount2, EUR)
 		r, err := m.Add(om)
-
 		if err != nil {
 			t.Error(err)
 		}
@@ -355,7 +355,6 @@ func TestMoney_Subtract(t *testing.T) {
 		m := New(tc.amount1, EUR)
 		om := New(tc.amount2, EUR)
 		r, err := m.Subtract(om)
-
 		if err != nil {
 			t.Error(err)
 		}
@@ -521,6 +520,19 @@ func TestMoney_Allocate2(t *testing.T) {
 	}
 }
 
+func TestAllocateOverflow(t *testing.T) {
+	m := New(math.MaxInt64, EUR)
+	_, err := m.Allocate(math.MaxInt, 1)
+	if err == nil {
+		t.Fatalf("expected an error, but got nil")
+	}
+
+	expectedErrorMessage := "sum of given ratios exceeds max int"
+	if err.Error() != expectedErrorMessage {
+		t.Fatalf("expected error message %q, but got %q", expectedErrorMessage, err.Error())
+	}
+}
+
 func TestMoney_Format(t *testing.T) {
 	tcs := []struct {
 		amount   int64
@@ -583,7 +595,6 @@ func TestMoney_AsMajorUnits(t *testing.T) {
 func TestMoney_Allocate3(t *testing.T) {
 	pound := New(100, GBP)
 	parties, err := pound.Allocate(33, 33, 33)
-
 	if err != nil {
 		t.Error(err)
 	}
@@ -655,7 +666,6 @@ func TestMoney_Comparison(t *testing.T) {
 		t.Errorf("Expected %d Equals to %d == %d got %d", anotherTwoEuros.amount,
 			twoEuros.amount, 0, r)
 	}
-
 }
 
 func TestMoney_Currency(t *testing.T) {
@@ -717,7 +727,6 @@ func TestDefaultMarshal(t *testing.T) {
 	expected := `{"amount":12345,"currency":"IQD"}`
 
 	b, err := json.Marshal(given)
-
 	if err != nil {
 		t.Error(err)
 	}
@@ -730,7 +739,6 @@ func TestDefaultMarshal(t *testing.T) {
 	expected = `{"amount":0,"currency":""}`
 
 	b, err = json.Marshal(given)
-
 	if err != nil {
 		t.Error(err)
 	}
@@ -749,7 +757,6 @@ func TestCustomMarshal(t *testing.T) {
 	}
 
 	b, err := json.Marshal(given)
-
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
This PR addresses an integer overflow issue in the `Allocate` function. When the sum of given ratios exceeds the maximum value for an `int64`, it results in a negative value, causing runtime errors. This fix includes:
- Updating the `Allocate` function to check for potential overflows.
- Adding a new test case to ensure the error is correctly handled.

## Related Issues

- Fixes  #136 
