### PR TITLE
[ISSUE#149] MXN fraction changed to 4

### DIFF
--- a/currency.go
+++ b/currency.go
@@ -149,7 +149,7 @@ var currencies = Currencies{
 	MUR: {Decimal: ".", Thousand: ",", Code: MUR, Fraction: 2, NumericCode: "480", Grapheme: "\u20a8", Template: "$1"},
 	MVR: {Decimal: ".", Thousand: ",", Code: MVR, Fraction: 2, NumericCode: "462", Grapheme: "MVR", Template: "1 $"},
 	MWK: {Decimal: ".", Thousand: ",", Code: MWK, Fraction: 2, NumericCode: "454", Grapheme: "MK", Template: "$1"},
-	MXN: {Decimal: ".", Thousand: ",", Code: MXN, Fraction: 2, NumericCode: "484", Grapheme: "$", Template: "$1"},
+	MXN: {Decimal: ".", Thousand: ",", Code: MXN, Fraction: 4, NumericCode: "484", Grapheme: "$", Template: "$1"},
 	MYR: {Decimal: ".", Thousand: ",", Code: MYR, Fraction: 2, NumericCode: "458", Grapheme: "RM", Template: "$1"},
 	MZN: {Decimal: ".", Thousand: ",", Code: MZN, Fraction: 2, NumericCode: "943", Grapheme: "MT", Template: "$1"},
 	NAD: {Decimal: ".", Thousand: ",", Code: NAD, Fraction: 2, NumericCode: "516", Grapheme: "$", Template: "$1"},


### PR DESCRIPTION
I have addressed [issue#149](https://github.com/Rhymond/go-money/issues/149) and changed the fraction for MXN from 2 to 4. Please review the PR and let me know if any other changes are required.

## Summary by Sourcery

Update the MXN currency fraction from 2 to 4 in the currency configuration to resolve issue #149.

Bug Fixes:
- Change the fraction for the MXN currency from 2 to 4 to address issue #149.