### PR TITLE
Fix issue 156 add xcg currency support

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -170,6 +170,7 @@ const (
 	XAG = "XAG"
 	XAU = "XAU"
 	XCD = "XCD"
+	XCG = "XCG"
 	XDR = "XDR"
 	XOF = "XOF"
 	XPF = "XPF"

--- a/currency.go
+++ b/currency.go
@@ -214,6 +214,7 @@ var currencies = Currencies{
 	XAG: {Decimal: ".", Thousand: ",", Code: XAG, Fraction: 0, NumericCode: "961", Grapheme: "oz t", Template: "1 $"},
 	XAU: {Decimal: ".", Thousand: ",", Code: XAU, Fraction: 0, NumericCode: "959", Grapheme: "oz t", Template: "1 $"},
 	XCD: {Decimal: ".", Thousand: ",", Code: XCD, Fraction: 2, NumericCode: "951", Grapheme: "$", Template: "$1"},
+	XCG: {Decimal: ",", Thousand: ".", Code: XCG, Fraction: 2, NumericCode: "532", Grapheme: "Cg", Template: "$1"},
 	XDR: {Decimal: ".", Thousand: ",", Code: XDR, Fraction: 0, NumericCode: "960", Grapheme: "SDR", Template: "1 $"},
 	XOF: {Decimal: ".", Thousand: ",", Code: XOF, Fraction: 0, NumericCode: "952", Grapheme: "CFA", Template: "1 $"},
 	XPF: {Decimal: ".", Thousand: ",", Code: XPF, Fraction: 0, NumericCode: "953", Grapheme: "₣", Template: "1 $"},


### PR DESCRIPTION
## [Issue link](https://github.com/Rhymond/go-money/issues/156) 

## Description:
This PR adds support for the `XCG` (Caribbean Guilder) currency, which replaces the existing `ANG` (Netherlands Antillean guilder) currency for Curaçao and Sint Maarten. This currency launched as the official currency for Curaçao and Sint Maarten on March 31, 2025.

Changes introduced:
- Addition of `XCG` in constants.go
- Addition of entry for `XCG` currency in `currencies` var in file currency.go

## Summary by Sourcery

New Features:
- Add XCG currency to the supported currencies list with its specific formatting and numeric code