### PR TITLE
Adds NewFromFloatWithRound to avoid precision loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,13 @@ Initialize Money by using smallest unit value (e.g 100 represents 1 pound). Use 
 ```go
 pound := money.New(100, money.GBP)
 ```
-Or initialize Money using the direct amount.
+Or initialize Money using the direct amount (without rounding, truncate the decimal part down).
 ```go
 quarterEuro := money.NewFromFloat(0.25, money.EUR)
+```
+Or initialize Money using the direct amount with rounding (round with `math.Round`).
+```go
+quarterEuro := money.NewFromFloatWithRound(0.25, money.EUR)
 ```
 Comparison
 -

--- a/money.go
+++ b/money.go
@@ -94,6 +94,17 @@ func NewFromFloat(amount float64, code string) *Money {
 	return New(int64(amount*currencyDecimals), code)
 }
 
+// NewFromFloatWithRound creates and returns new instance of Money from a float64.
+// It rounds trailing decimals to the nearest integer as math.Round does.
+func NewFromFloatWithRound(amount float64, code string) *Money {
+	currency := newCurrency(code).get()
+	currencyDecimals := math.Pow10(currency.Fraction)
+	return &Money{
+		amount:   int64(math.Round(amount * currencyDecimals)),
+		currency: currency,
+	}
+}
+
 // Currency returns the currency used by Money.
 func (m *Money) Currency() *Currency {
 	return m.currency

--- a/money_test.go
+++ b/money_test.go
@@ -819,6 +819,12 @@ func TestNewFromFloat(t *testing.T) {
 	if m.amount != -12 {
 		t.Errorf("Expected %d got %d", -12, m.amount)
 	}
+
+	m = NewFromFloat(147.23, BRL)
+
+	if m.amount != 14722 {
+		t.Errorf("Expected %d got %d", 14722, m.amount)
+	}
 }
 
 func TestNewFromFloat_WithUnregisteredCurrency(t *testing.T) {
@@ -827,6 +833,60 @@ func TestNewFromFloat_WithUnregisteredCurrency(t *testing.T) {
 	const expectedDisplay = "12.34FOO"
 
 	m := NewFromFloat(12.34, currencyFooCode)
+
+	if m.amount != expectedAmount {
+		t.Errorf("Expected amount %d got %d", expectedAmount, m.amount)
+	}
+
+	if m.currency.Code != currencyFooCode {
+		t.Errorf("Expected currency code %s got %s", currencyFooCode, m.currency.Code)
+	}
+
+	if m.Display() != expectedDisplay {
+		t.Errorf("Expected display %s got %s", expectedDisplay, m.Display())
+	}
+}
+
+func TestNewFromFloatWithRound(t *testing.T) {
+	m := NewFromFloatWithRound(12.34, EUR)
+
+	if m.amount != 1234 {
+		t.Errorf("Expected %d got %d", 1234, m.amount)
+	}
+
+	if m.currency.Code != EUR {
+		t.Errorf("Expected currency %s got %s", EUR, m.currency.Code)
+	}
+
+	m = NewFromFloatWithRound(12.34, "eur")
+
+	if m.amount != 1234 {
+		t.Errorf("Expected %d got %d", 1234, m.amount)
+	}
+
+	if m.currency.Code != EUR {
+		t.Errorf("Expected currency %s got %s", EUR, m.currency.Code)
+	}
+
+	m = NewFromFloatWithRound(-0.125, EUR)
+
+	if m.amount != -13 {
+		t.Errorf("Expected %d got %d", -13, m.amount)
+	}
+
+	m = NewFromFloatWithRound(147.23, BRL)
+
+	if m.amount != 14723 {
+		t.Errorf("Expected %d got %d", 14723, m.amount)
+	}
+}
+
+func TestNewFromFloatWithRound_WithUnregisteredCurrency(t *testing.T) {
+	const currencyFooCode = "FOO"
+	const expectedAmount = 1234
+	const expectedDisplay = "12.34FOO"
+
+	m := NewFromFloatWithRound(12.34, currencyFooCode)
 
 	if m.amount != expectedAmount {
 		t.Errorf("Expected amount %d got %d", expectedAmount, m.amount)

--- a/money_test.go
+++ b/money_test.go
@@ -879,6 +879,23 @@ func TestNewFromFloatWithRound(t *testing.T) {
 	if m.amount != 14723 {
 		t.Errorf("Expected %d got %d", 14723, m.amount)
 	}
+
+	m = NewFromFloatWithRound(0.125, EUR)
+	if m.amount != 13 {
+		t.Errorf("Expected %d got %d", 13, m.amount)
+	}
+
+	m = NewFromFloatWithRound(0.125, JPY)
+
+	if m.amount != 0 {
+		t.Errorf("Expected %d got %d", 0, m.amount)
+	}
+
+	m = NewFromFloatWithRound(0.125, IQD)
+
+	if m.amount != 125 {
+		t.Errorf("Expected %d got %d", 125, m.amount)
+	}
 }
 
 func TestNewFromFloatWithRound_WithUnregisteredCurrency(t *testing.T) {


### PR DESCRIPTION
## Add `NewFromFloatWithRound` function to fix precision loss in float-to-money conversion

### Problem

The existing `NewFromFloat` function has precision loss issues due to its behavior of always truncating trailing decimals down (using `int64()` conversion). This leads to unexpected results when converting precise decimal values:

```go
m := NewFromFloat(147.23, USD)
fmt.Println(m.Display()) // --> $147.22 (lost penny) ❌

m := NewFromFloat(-0.125, EUR) 
// Results in amount: -12 (truncated down)
```

This behavior is particularly problematic when:
- Working with exact decimal amounts that match the currency's precision (e.g. 147.23 - two decimal places with currency USD, Fraction = 2)
- Converting financial data where precision is critical
- Dealing with negative values where truncation becomes more counterintuitive

### Solution

This PR introduces `NewFromFloatWithRound`, a new function that uses proper mathematical rounding (`math.Round`) instead of truncation:

```go
// NewFromFloatWithRound creates and returns new instance of Money from a float64.
// It rounds trailing decimals to the nearest integer as math.Round does.
func NewFromFloatWithRound(amount float64, code string) *Money {
    currency := newCurrency(code).get()
    currencyDecimals := math.Pow10(currency.Fraction)
    return &Money{
        amount:   int64(math.Round(amount * currencyDecimals)),
        currency: currency,
    }
}
```

### Key Improvements

1. **Precision preservation**: Exact decimal values are preserved correctly
   ```go
   m := NewFromFloatWithRound(147.23, USD)
   fmt.Println(m.Display()) // --> $147.23 ✅
   ```

2. **Proper rounding behavior**: Uses banker's rounding (round half to even) via `math.Round`
   ```go
   NewFromFloatWithRound(-147.23, EUR)  // amount: -14723 (rounded)
   vs
   NewFromFloat(-147.23, EUR)           // amount: -14722 (truncated)
   ```

3. **Consistent with mathematical expectations**: Follows standard rounding rules instead of always rounding down

### Backward Compatibility

- The existing `NewFromFloat` function remains unchanged to maintain backward compatibility
- Applications that specifically need truncation behavior can continue using the original function
- The new function provides an opt-in solution for applications requiring proper rounding

### Usage Examples

```go
// Old behavior (truncation)
m1 := NewFromFloat(147.23, USD)      // $147.22
m2 := NewFromFloat(-0.125, EUR)      // -€0.12

// New behavior (proper rounding) 
m3 := NewFromFloatWithRound(147.23, USD)  // $147.23
m4 := NewFromFloatWithRound(-0.125, EUR)  // -€0.13
```

This enhancement addresses precision issues while maintaining full backward compatibility, giving developers the choice between truncation and proper rounding based on their specific use cases.

## Summary by Sourcery

Add NewFromFloatWithRound to handle float-to-money conversion using math.Round instead of truncation, maintaining backward compatibility, and update tests and documentation accordingly

New Features:
- Add NewFromFloatWithRound function for float-to-money conversion with proper mathematical rounding

Enhancements:
- Preserve existing NewFromFloat behavior for backward compatibility

Documentation:
- Update README to document the new rounding-based initialization method

Tests:
- Add unit tests for NewFromFloatWithRound covering positive, negative, and unregistered currency cases