### PR TITLE
Add new constructor that receives already resolved currency to avoid …

### DIFF
--- a/money.go
+++ b/money.go
@@ -87,6 +87,15 @@ func New(amount int64, code string) *Money {
 	}
 }
 
+// NewWithCurrency creates and returns a new instance of Money with a pre-resolved Currency,
+// skipping the currency lookup. The caller must ensure currency is non-nil.
+func NewWithCurrency(amount int64, currency *Currency) *Money {
+	return &Money{
+		amount:   amount,
+		currency: currency,
+	}
+}
+
 // NewFromFloat creates and returns new instance of Money from a float64.
 // Always rounding trailing decimals down.
 func NewFromFloat(amount float64, code string) *Money {

--- a/money_test.go
+++ b/money_test.go
@@ -55,8 +55,7 @@ func TestNewWithCurrency(t *testing.T) {
 
 	r, err := m.Equals(om)
 	if err != nil || !r {
-		t.Errorf("Expected %d Equals %d", m.amount,
-			om.amount)
+		t.Errorf("Expected %d (%s) Equals %d (%s)", m.amount, m.currency.Code, om.amount, om.currency.Code)
 	}
 }
 

--- a/money_test.go
+++ b/money_test.go
@@ -48,6 +48,18 @@ func TestNew_WithUnregisteredCurrency(t *testing.T) {
 	}
 }
 
+func TestNewWithCurrency(t *testing.T) {
+	m := New(1, EUR)
+
+	om := NewWithCurrency(1, m.Currency())
+
+	r, err := m.Equals(om)
+	if err != nil || !r {
+		t.Errorf("Expected %d Equals %d", m.amount,
+			om.amount)
+	}
+}
+
 func TestCurrency(t *testing.T) {
 	code := "MOCK"
 	decimals := 5


### PR DESCRIPTION
Hi @Rhymond,

This PR adds a new constructor that already receives the resolved currency. 

Right now, all constructors have to allocate a temporary currency to just lookup if it exists (it also requires to scan the currency code and convert to uppercase if required). It becomes even worse when using the `NewFromFloat` that forces a `math.Pow10` for each call.

With this new constructor, callers can implement currencies cache mechanisms to reduce this overhead.

## Summary by Sourcery

Add a constructor that creates Money instances from an already resolved currency to avoid repeated currency lookups.

New Features:
- Introduce NewWithCurrency constructor to create Money with a pre-resolved Currency.

Tests:
- Add a unit test verifying Money created with NewWithCurrency is equal to one created with the existing constructor.