### PR TITLE
feat: add Percentage method to Money type

### DIFF
--- a/money.go
+++ b/money.go
@@ -340,6 +340,16 @@ func (m *Money) Allocate(rs ...int) ([]*Money, error) {
 	return ms, nil
 }
 
+// Percentage returns new Money struct with value representing given percentage of the original Money.
+// The percentage must be between 0 and 100 (inclusive).
+func (m *Money) Percentage(percentage int64) (*Money, error) {
+	if percentage < 0 || percentage > 100 {
+		return nil, errors.New("percentage must be between 0 and 100")
+	}
+
+	return &Money{amount: mutate.calc.allocate(m.amount, percentage, 100), currency: m.currency}, nil
+}
+
 // Display lets represent Money struct as string in given Currency value.
 func (m *Money) Display() string {
 	c := m.currency.get()

--- a/money_test.go
+++ b/money_test.go
@@ -642,6 +642,100 @@ func TestAllocateOverflow(t *testing.T) {
 	}
 }
 
+func TestMoney_Percentage(t *testing.T) {
+	tcs := []struct {
+		name       string
+		amount     int64
+		percentage int64
+		expected   int64
+		expectErr  bool
+	}{
+		{"50% of 100", 100, 50, 50, false},
+		{"25% of 100", 100, 25, 25, false},
+		{"100% of 100", 100, 100, 100, false},
+		{"0% of 100", 100, 0, 0, false},
+		{"50% of 1", 1, 50, 0, false},
+		{"33% of 100", 100, 33, 33, false},
+		{"50% of -100", -100, 50, -50, false},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			m := New(tc.amount, EUR)
+			r, err := m.Percentage(tc.percentage)
+
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("Expected error for %s, but got nil", tc.name)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error for %s: %v", tc.name, err)
+				}
+				if r.Amount() != tc.expected {
+					t.Errorf("Expected %d%% of %d to be %d, got %d", tc.percentage, tc.amount, tc.expected, r.Amount())
+				}
+			}
+		})
+	}
+}
+
+func TestMoney_Percentage_BoundaryValues(t *testing.T) {
+	tcs := []struct {
+		name       string
+		percentage int64
+		expected   int64
+	}{
+		{"percentage=0", 0, 0},
+		{"percentage=100", 100, 100},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			m := New(100, EUR)
+			r, err := m.Percentage(tc.percentage)
+
+			if err != nil {
+				t.Errorf("Unexpected error for %s: %v", tc.name, err)
+			}
+			if r.Amount() != tc.expected {
+				t.Errorf("Expected %d, got %d", tc.expected, r.Amount())
+			}
+		})
+	}
+}
+
+func TestMoney_Percentage_InvalidInput(t *testing.T) {
+	tcs := []struct {
+		name       string
+		percentage int64
+	}{
+		{"percentage=-1", -1},
+		{"percentage=101", 101},
+		{"percentage=-100", -100},
+		{"percentage=200", 200},
+	}
+
+	expectedErrMsg := "percentage must be between 0 and 100"
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			m := New(100, EUR)
+			r, err := m.Percentage(tc.percentage)
+
+			if err == nil {
+				t.Errorf("Expected error for %s, but got nil", tc.name)
+			}
+			if err != nil && err.Error() != expectedErrMsg {
+				t.Errorf("Expected error message %q, got %q", expectedErrMsg, err.Error())
+			}
+			if r != nil {
+				t.Errorf("Expected nil result for %s, but got %v", tc.name, r)
+			}
+		})
+	}
+}
+
 func TestMoney_Format(t *testing.T) {
 	tcs := []struct {
 		amount   int64


### PR DESCRIPTION
## Summary

Adds a `Percentage` method to the `Money` type for calculating integer percentage portions of a monetary amount.

```go
func (m *Money) Percentage(percentage int64) (*Money, error)
```

- Returns a new `Money` representing `percentage`% of the original amount
- Reuses the existing `calculator.allocate` path (`amount * p / 100`) — consistent with `Allocate` and `Split`
- Returns `error` when `percentage` is outside `[0, 100]`
- Currency is preserved on the returned value

## Tests

Three test functions added to `money_test.go`:

| Test | Scenarios |
|------|-----------|
| `TestMoney_Percentage` | 50%, 25%, 100%, 0%, 33%, negative amount |
| `TestMoney_Percentage_BoundaryValues` | percentage=0, percentage=100 |
| `TestMoney_Percentage_InvalidInput` | -1, 101, -100, 200 |

All existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for computing percentage portions of a Money amount with validation for allowed ranges.

New Features:
- Add a Percentage method on Money to return a new monetary value representing a given percentage of the original amount.

Tests:
- Add unit tests covering typical percentage calculations, boundary values, and invalid percentage inputs for the new Money.Percentage method.