### PR TITLE
docs: expand IsZero/IsPositive/IsNegative godoc examples

### DIFF
--- a/money_example_test.go
+++ b/money_example_test.go
@@ -61,26 +61,35 @@ func ExampleMoney_comparisons() {
 }
 
 func ExampleMoney_IsZero() {
-	pound := money.New(100, "GBP")
-	fmt.Println(pound.IsZero())
+	fmt.Println(money.New(0, "GBP").IsZero())
+	fmt.Println(money.New(100, "GBP").IsZero())
+	fmt.Println(money.New(-100, "GBP").IsZero())
 
 	// Output:
+	// true
+	// false
 	// false
 }
 
 func ExampleMoney_IsPositive() {
-	pound := money.New(100, "GBP")
-	fmt.Println(pound.IsPositive())
+	fmt.Println(money.New(100, "GBP").IsPositive())
+	fmt.Println(money.New(0, "GBP").IsPositive())
+	fmt.Println(money.New(-100, "GBP").IsPositive())
 
 	// Output:
 	// true
+	// false
+	// false
 }
 
 func ExampleMoney_IsNegative() {
-	pound := money.New(100, "GBP")
-	fmt.Println(pound.IsNegative())
+	fmt.Println(money.New(-100, "GBP").IsNegative())
+	fmt.Println(money.New(0, "GBP").IsNegative())
+	fmt.Println(money.New(100, "GBP").IsNegative())
 
 	// Output:
+	// true
+	// false
 	// false
 }
 


### PR DESCRIPTION
## Summary

The existing `ExampleMoney_IsZero`, `ExampleMoney_IsPositive`, and `ExampleMoney_IsNegative` functions each showed only one state, which is insufficient to communicate the method semantics through godoc.

This PR expands each example to demonstrate all three cases — positive, zero, and negative — so readers can understand the full behaviour at a glance without reading the implementation.

**Before (IsZero):**
```go
func ExampleMoney_IsZero() {
    pound := money.New(100, "GBP")
    fmt.Println(pound.IsZero())
    // Output:
    // false
}
```

**After (IsZero):**
```go
func ExampleMoney_IsZero() {
    fmt.Println(money.New(0, "GBP").IsZero())
    fmt.Println(money.New(100, "GBP").IsZero())
    fmt.Println(money.New(-100, "GBP").IsZero())
    // Output:
    // true
    // false
    // false
}
```

All existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Expand Money.IsZero, Money.IsPositive, and Money.IsNegative examples to cover positive, zero, and negative amounts so behaviour is clear in godoc.