### PR TITLE
feat: add PercentageFloat method for decimal percentage support

### DIFF
--- a/money.go
+++ b/money.go
@@ -350,6 +350,22 @@ func (m *Money) Percentage(percentage int64) (*Money, error) {
 	return &Money{amount: mutate.calc.allocate(m.amount, percentage, 100), currency: m.currency}, nil
 }
 
+// PercentageFloat returns new Money struct with value representing given percentage of the original Money.
+// The percentage must be between 0.0 and 100.0 (inclusive).
+// The calculation uses integer arithmetic with a precision of 1e9 to avoid floating point precision issues.
+// Note: The result is truncated towards zero, e.g., 33.3% of 300 = 99 (not 99.9).
+func (m *Money) PercentageFloat(percentage float64) (*Money, error) {
+	if percentage < 0.0 || percentage > 100.0 {
+		return nil, errors.New("percentage must be between 0 and 100")
+	}
+
+	const precision = 1e9
+	numerator := int64(percentage * precision)
+	denominator := int64(100 * precision)
+
+	return &Money{amount: mutate.calc.allocate(m.amount, numerator, denominator), currency: m.currency}, nil
+}
+
 // Display lets represent Money struct as string in given Currency value.
 func (m *Money) Display() string {
 	c := m.currency.get()

--- a/money.go
+++ b/money.go
@@ -340,6 +340,16 @@ func (m *Money) Allocate(rs ...int) ([]*Money, error) {
 	return ms, nil
 }
 
+// Percentage returns new Money struct with value representing given percentage of the original Money.
+// The percentage must be between 0 and 100 (inclusive).
+func (m *Money) Percentage(percentage int64) (*Money, error) {
+	if percentage < 0 || percentage > 100 {
+		return nil, errors.New("percentage must be between 0 and 100")
+	}
+
+	return &Money{amount: mutate.calc.allocate(m.amount, percentage, 100), currency: m.currency}, nil
+}
+
 // Display lets represent Money struct as string in given Currency value.
 func (m *Money) Display() string {
 	c := m.currency.get()

--- a/money_test.go
+++ b/money_test.go
@@ -642,6 +642,100 @@ func TestAllocateOverflow(t *testing.T) {
 	}
 }
 
+func TestMoney_Percentage(t *testing.T) {
+	tcs := []struct {
+		name       string
+		amount     int64
+		percentage int64
+		expected   int64
+		expectErr  bool
+	}{
+		{"50% of 100", 100, 50, 50, false},
+		{"25% of 100", 100, 25, 25, false},
+		{"100% of 100", 100, 100, 100, false},
+		{"0% of 100", 100, 0, 0, false},
+		{"50% of 1", 1, 50, 0, false},
+		{"33% of 100", 100, 33, 33, false},
+		{"50% of -100", -100, 50, -50, false},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			m := New(tc.amount, EUR)
+			r, err := m.Percentage(tc.percentage)
+
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("Expected error for %s, but got nil", tc.name)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error for %s: %v", tc.name, err)
+				}
+				if r.Amount() != tc.expected {
+					t.Errorf("Expected %d%% of %d to be %d, got %d", tc.percentage, tc.amount, tc.expected, r.Amount())
+				}
+			}
+		})
+	}
+}
+
+func TestMoney_Percentage_BoundaryValues(t *testing.T) {
+	tcs := []struct {
+		name       string
+		percentage int64
+		expected   int64
+	}{
+		{"percentage=0", 0, 0},
+		{"percentage=100", 100, 100},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			m := New(100, EUR)
+			r, err := m.Percentage(tc.percentage)
+
+			if err != nil {
+				t.Errorf("Unexpected error for %s: %v", tc.name, err)
+			}
+			if r.Amount() != tc.expected {
+				t.Errorf("Expected %d, got %d", tc.expected, r.Amount())
+			}
+		})
+	}
+}
+
+func TestMoney_Percentage_InvalidInput(t *testing.T) {
+	tcs := []struct {
+		name       string
+		percentage int64
+	}{
+		{"percentage=-1", -1},
+		{"percentage=101", 101},
+		{"percentage=-100", -100},
+		{"percentage=200", 200},
+	}
+
+	expectedErrMsg := "percentage must be between 0 and 100"
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			m := New(100, EUR)
+			r, err := m.Percentage(tc.percentage)
+
+			if err == nil {
+				t.Errorf("Expected error for %s, but got nil", tc.name)
+			}
+			if err != nil && err.Error() != expectedErrMsg {
+				t.Errorf("Expected error message %q, got %q", expectedErrMsg, err.Error())
+			}
+			if r != nil {
+				t.Errorf("Expected nil result for %s, but got %v", tc.name, r)
+			}
+		})
+	}
+}
+
 func TestMoney_Format(t *testing.T) {
 	tcs := []struct {
 		amount   int64

--- a/money_test.go
+++ b/money_test.go
@@ -736,6 +736,75 @@ func TestMoney_Percentage_InvalidInput(t *testing.T) {
 	}
 }
 
+func TestMoney_PercentageFloat(t *testing.T) {
+	tcs := []struct {
+		name       string
+		amount     int64
+		percentage float64
+		expected   int64
+		expectErr  bool
+	}{
+		{"12.5% of 200", 200, 12.5, 25, false},
+		{"6.25% of 800", 800, 6.25, 50, false},
+		{"33.3% of 300 (truncated)", 300, 33.3, 99, false},
+		{"50.0% of 100", 100, 50.0, 50, false},
+		{"0.0% of 100", 100, 0.0, 0, false},
+		{"100.0% of 100", 100, 100.0, 100, false},
+		{"12.5% of -200", -200, 12.5, -25, false},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			m := New(tc.amount, USD)
+			r, err := m.PercentageFloat(tc.percentage)
+
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("Expected error for %s, but got nil", tc.name)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error for %s: %v", tc.name, err)
+				}
+				if r.Amount() != tc.expected {
+					t.Errorf("Expected %.1f%% of %d to be %d, got %d", tc.percentage, tc.amount, tc.expected, r.Amount())
+				}
+			}
+		})
+	}
+}
+
+func TestMoney_PercentageFloat_InvalidInput(t *testing.T) {
+	tcs := []struct {
+		name       string
+		percentage float64
+	}{
+		{"percentage=-0.1", -0.1},
+		{"percentage=100.1", 100.1},
+		{"percentage=-100.0", -100.0},
+		{"percentage=200.5", 200.5},
+	}
+
+	expectedErrMsg := "percentage must be between 0 and 100"
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			m := New(100, USD)
+			r, err := m.PercentageFloat(tc.percentage)
+
+			if err == nil {
+				t.Errorf("Expected error for %s, but got nil", tc.name)
+			}
+			if err != nil && err.Error() != expectedErrMsg {
+				t.Errorf("Expected error message %q, got %q", expectedErrMsg, err.Error())
+			}
+			if r != nil {
+				t.Errorf("Expected nil result for %s, but got %v", tc.name, r)
+			}
+		})
+	}
+}
+
 func TestMoney_Format(t *testing.T) {
 	tcs := []struct {
 		amount   int64


### PR DESCRIPTION
## Problem

`Percentage(int64)` only supports whole-number rates. Real-world tax and discount calculations frequently require decimal percentages (12.5% VAT, 6.25% sales tax, etc.) that cannot be represented.

## Solution

Adds `PercentageFloat(percentage float64) (*Money, error)` that accepts a `float64` rate in `[0.0, 100.0]` while keeping all arithmetic in integer space.

### Implementation approach

Instead of multiplying `amount` by a float, the method scales the percentage to a large integer numerator/denominator pair (precision = 1e9) and delegates to the existing `calculator.allocate(amount, numerator, denominator)` path:

```go
const precision = 1e9
numerator  := int64(percentage * precision)   // e.g. 12.5 → 12_500_000_000
denominator := int64(100 * precision)          // always 100_000_000_000
```

This avoids floating-point amounts entirely, consistent with the library's design.

> **Truncation note**: results are truncated towards zero (e.g. 33.3% of $3.00 → $0.99, not $1.00). This matches the behaviour of `Allocate` and `Split`.

## Tests

| Case | Input | Expected |
|------|-------|----------|
| 12.5% of $200 | `PercentageFloat(12.5)` on 200 | 25 |
| 6.25% of $800 | `PercentageFloat(6.25)` on 800 | 50 |
| 33.3% of $300 (truncation) | `PercentageFloat(33.3)` on 300 | 99 |
| Boundary 0.0% | `PercentageFloat(0.0)` | 0 |
| Boundary 100.0% | `PercentageFloat(100.0)` | 100 |
| Invalid -0.1 | error | — |
| Invalid 100.1 | error | — |

All existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add integer- and float-based percentage calculation helpers to Money with validation and coverage tests.

New Features:
- Introduce Money.Percentage to compute whole-number percentage values of a Money amount with range validation.
- Introduce Money.PercentageFloat to compute decimal percentage values of a Money amount using high-precision integer arithmetic and truncation toward zero.

Tests:
- Add unit tests for Money.Percentage, including normal, boundary, and invalid percentage cases.
- Add unit tests for Money.PercentageFloat, including fractional, negative-amount, boundary, and invalid percentage cases.